### PR TITLE
"Quantity" form field fixed.

### DIFF
--- a/src/components/RopeDataSheetForm.vue
+++ b/src/components/RopeDataSheetForm.vue
@@ -36,7 +36,7 @@
             label="Colli"
             dense
             outlined
-            @change="onQuantityChange"
+            @input="onQuantityChange"
           ></v-text-field>
         </v-col>
       </v-row>


### PR DESCRIPTION
Bug fixed: now when the "quantity" changes, we immediately calculate "ropeLength" and "ropeMass" form fields [through "onQuantityChanges()" method]. In the previous state, in order to trigger the calculation, we had to remove the focus on the "quantity" form field. This was often causing mismatching between the filled form and the PDF preview.